### PR TITLE
Hotfix | Cambiar in? por include? en chequeo de ruta para controladores

### DIFF
--- a/lib/traceroute.rb
+++ b/lib/traceroute.rb
@@ -26,12 +26,12 @@ class Traceroute
     # Los if implementados dentro del loop es para limpiar ignored_action en caso de que se haya agregado una ruta completa al controlador
     if config_filename && (config = YAML.load_file(config_filename))
       (config['ignore_unreachable_actions'] || []).each do |ignored_action|
-        ignored_action = ignored_action.split('/controllers/').last.gsub(/_controller\.rb/, '').gsub(/_controller/, '') if '/controllers/'.in?(ignored_action)
+        ignored_action = ignored_action.split('/controllers/').last.gsub(/_controller\.rb/, '').gsub(/_controller/, '') if ignored_action.include?('/controllers/')
         @ignored_unreachable_actions << Regexp.new(ignored_action)
       end
 
       (config['ignore_unused_routes'] || []).each do |ignored_action|
-        ignored_action = ignored_action.split('/controllers/').last.gsub(/_controller\.rb/, '').gsub(/_controller/, '') if '/controllers/'.in?(ignored_action)
+        ignored_action = ignored_action.split('/controllers/').last.gsub(/_controller\.rb/, '').gsub(/_controller/, '') if ignored_action.include?('/controllers/')
         @ignored_unused_routes << Regexp.new(ignored_action)
       end
     end


### PR DESCRIPTION
`in?` no estaba funcionando correctamente al chequear el string de la ruta, fallando en algunos casos. Ahora con `include?` funciona bien.